### PR TITLE
Cap FluentAssertions to Open Licence

### DIFF
--- a/MFT.Test/MFT.Test.csproj
+++ b/MFT.Test/MFT.Test.csproj
@@ -15,8 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions">
-            <Version>7.0.0</Version>
+        <PackageReference Include="FluentAssertions" Version="[7.0.0,8.0.0)" />
         </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk">
             <Version>17.12.0</Version>


### PR DESCRIPTION
Due to the mess of [here](https://github.com/fluentassertions/fluentassertions/pull/2943). Protects against License Change 